### PR TITLE
Remove twitter

### DIFF
--- a/example.html
+++ b/example.html
@@ -12,6 +12,10 @@
     min-width: 3.8125em;
   }
 
+  .m-social__item--no-count {
+    min-width: 0;
+  }
+
   .m-social__link {
     color: #fff;
     text-decoration: none;
@@ -84,6 +88,17 @@
 </style>
 
 <ul class="m-social">
+  <li class="m-social__item m-social__item--no-count">
+    <a href="https://twitter.com/intent/tweet?text=The+Innovation+Enterprise+Group&url=https%3A%2F%2Fchannels.theinnovationenterprise.com&via=iegroup" class="m-social__link">
+      <picture>
+        <!--[if IE 9]><video style="display: none;"><![endif]-->
+        <source srcset="images/twitter.svg" type="image/svg+xml">
+        <!--[if IE 9]></video><![endif]-->
+        <img class="m-social__icon" src="images/twitter.png" alt="Share on Twitter" width="32" height="32">
+      </picture>
+    </a>
+  </li>
+
   <li class="m-social__item">
     <a href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fchannels.theinnovationenterprise.com" class="m-social__link m-social__link--facebook">
       <picture>
@@ -94,17 +109,6 @@
       </picture>
 
       <span class="m-social__counter socialCount-facebook"></span>
-    </a>
-  </li>
-
-  <li class="m-social__item">
-    <a href="https://twitter.com/intent/tweet?text=The+Innovation+Enterprise+Group&url=https%3A%2F%2Fchannels.theinnovationenterprise.com&via=iegroup" class="m-social__link">
-      <picture>
-        <!--[if IE 9]><video style="display: none;"><![endif]-->
-        <source srcset="images/twitter.svg" type="image/svg+xml">
-        <!--[if IE 9]></video><![endif]-->
-        <img class="m-social__icon" src="images/twitter.png" alt="Share on Twitter" width="32" height="32">
-      </picture>
     </a>
   </li>
 

--- a/example.html
+++ b/example.html
@@ -8,27 +8,43 @@
   }
 
   .m-social__item {
-    text-align: center;
     display: inline-block;
+    min-width: 3.8125em;
   }
 
   .m-social__link {
+    color: #fff;
     text-decoration: none;
+    display: block;
+  }
+
+  .m-social__link--facebook {
+    background: #37589A;
+  }
+
+  .m-social__link--gplus {
+    background: #DA4A38;
+  }
+
+  .m-social__link--linkedin {
+    background: #006799;
+  }
+
+  .m-social__link--buffer {
+    background: #E2DDDB;
+  }
+
+  .m-social__icon {
+    display: inline-block;
+    vertical-align: middle;
   }
 
   .m-social__counter {
-    background: #ffe;
-    border: 1px solid #eaeaea;
-    border-radius: 3px;
-    text-align: center;
+    line-height: 1;
+    background: rgba(0,0,0,.3);
     padding: 0.5em;
-    position: relative;
-    display: block;
-    margin-top: 0.75em;
-  }
-
-  .m-social__counter.is-hidden {
-    display: none;
+    display: inline-block;
+    vertical-align: middle;
   }
 
   @supports (transform: rotate(45deg)) {
@@ -69,15 +85,16 @@
 
 <ul class="m-social">
   <li class="m-social__item">
-    <a href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fchannels.theinnovationenterprise.com" class="m-social__link">
+    <a href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fchannels.theinnovationenterprise.com" class="m-social__link m-social__link--facebook">
       <picture>
         <!--[if IE 9]><video style="display: none;"><![endif]-->
         <source srcset="images/facebook.svg" type="image/svg+xml">
         <!--[if IE 9]></video><![endif]-->
-        <img src="images/facebook.png" alt="Share on Facebook" width="32" height="32">
+        <img class="m-social__icon" src="images/facebook.png" alt="Share on Facebook" width="32" height="32">
       </picture>
+
+      <span class="m-social__counter socialCount-facebook"></span>
     </a>
-    <span class="m-social__counter socialCount-facebook is-hidden"></span>
   </li>
 
   <li class="m-social__item">
@@ -86,45 +103,48 @@
         <!--[if IE 9]><video style="display: none;"><![endif]-->
         <source srcset="images/twitter.svg" type="image/svg+xml">
         <!--[if IE 9]></video><![endif]-->
-        <img src="images/twitter.png" alt="Share on Twitter" width="32" height="32">
+        <img class="m-social__icon" src="images/twitter.png" alt="Share on Twitter" width="32" height="32">
       </picture>
     </a>
   </li>
 
   <li class="m-social__item">
-    <a href="https://plus.google.com/share?url=https%3A%2F%2Fchannels.theinnovationenterprise.com" class="m-social__link">
+    <a href="https://plus.google.com/share?url=https%3A%2F%2Fchannels.theinnovationenterprise.com" class="m-social__link m-social__link--gplus">
       <picture>
         <!--[if IE 9]><video style="display: none;"><![endif]-->
         <source srcset="images/gplus.svg" type="image/svg+xml">
         <!--[if IE 9]></video><![endif]-->
-        <img src="images/gplus.png" alt="Share on Google Plus" width="32" height="32">
+        <img class="m-social__icon" src="images/gplus.png" alt="Share on Google Plus" width="32" height="32">
       </picture>
+
+      <span class="m-social__counter socialCount-gplus"></span>
     </a>
-    <span class="m-social__counter socialCount-gplus is-hidden"></span>
   </li>
 
   <li class="m-social__item">
-    <a href="https://www.linkedin.com/shareArticle?mini=true&url=https%3A%2F%2Fchannels.theinnovationenterprise.com&title=The+Innovation+Enterprise+Group" class="m-social__link">
+    <a href="https://www.linkedin.com/shareArticle?mini=true&url=https%3A%2F%2Fchannels.theinnovationenterprise.com&title=The+Innovation+Enterprise+Group" class="m-social__link m-social__link--linkedin">
       <picture>
         <!--[if IE 9]><video style="display: none;"><![endif]-->
         <source srcset="images/linkedin.svg" type="image/svg+xml">
         <!--[if IE 9]></video><![endif]-->
-        <img src="images/linkedin.png" alt="Share on LinkedIn" width="32" height="32">
+        <img class="m-social__icon" src="images/linkedin.png" alt="Share on LinkedIn" width="32" height="32">
       </picture>
+
+      <span class="m-social__counter socialCount-linkedin"></span>
     </a>
-    <span class="m-social__counter socialCount-linkedin is-hidden"></span>
   </li>
 
   <li class="m-social__item">
-    <a href="http://bufferapp.com/add?text=The+Innovation+Enterprise+Group&url=https%3A%2F%2Fchannels.theinnovationenterprise.com" class="m-social__link">
+    <a href="http://bufferapp.com/add?text=The+Innovation+Enterprise+Group&url=https%3A%2F%2Fchannels.theinnovationenterprise.com" class="m-social__link m-social__link--buffer">
       <picture>
         <!--[if IE 9]><video style="display: none;"><![endif]-->
         <source srcset="images/buffer.svg" type="image/svg+xml">
         <!--[if IE 9]></video><![endif]-->
-        <img src="images/buffer.png" alt="Share on Buffer" width="32" height="32">
+        <img class="m-social__icon" src="images/buffer.png" alt="Share on Buffer" width="32" height="32">
       </picture>
+
+      <span class="m-social__counter socialCount-buffer"></span>
     </a>
-    <span class="m-social__counter socialCount-buffer is-hidden"></span>
   </li>
 </ul>
 

--- a/example.html
+++ b/example.html
@@ -81,7 +81,7 @@
   </li>
 
   <li class="m-social__item">
-    <a href="https://twitter.com/intent/tweet?text=The+Innovation+Enterprise+Group&url=https%3A%2F%2Fchannels.theinnovationenterprise.com&via=iegroup" class="m-social__link" class="m-social__link">
+    <a href="https://twitter.com/intent/tweet?text=The+Innovation+Enterprise+Group&url=https%3A%2F%2Fchannels.theinnovationenterprise.com&via=iegroup" class="m-social__link">
       <picture>
         <!--[if IE 9]><video style="display: none;"><![endif]-->
         <source srcset="images/twitter.svg" type="image/svg+xml">
@@ -89,7 +89,6 @@
         <img src="images/twitter.png" alt="Share on Twitter" width="32" height="32">
       </picture>
     </a>
-    <span class="m-social__counter socialCount-twitter is-hidden"></span>
   </li>
 
   <li class="m-social__item">

--- a/social-count.js
+++ b/social-count.js
@@ -6,7 +6,6 @@
   this.url = this.options.url || window.location.href;
 
   var networks = {
-    twitter: twitter,
     facebook: facebook,
     linkedin: linkedin,
     gplus: gplus,
@@ -76,18 +75,6 @@
    * Handle the response from each network
    *
    ********/
-  // Twitter
-  function twitter(url, callback) {
-    jQuery.ajax({
-      type: 'GET',
-      dataType: 'jsonp',
-      url: 'https://cdn.api.twitter.com/1/urls/count.json',
-      data: {'url': url}
-    })
-    .done(function(data) { callback(data.count); })
-    .fail(function(data) { callback(0); });
-  }
-
   // Facebook
   // Has CORS enabled so can use XHR
   function facebook(url, callback) {


### PR DESCRIPTION
## Issue

Twitter have removed their share count endpoint.
## Solution
- Removed the code that did the call to Twitter.
- Removed the `twitter` property from the `networks` object.
- Updated the design so one missing counter doesn't throw the whole thing.

<img width="397" alt="screen shot 2015-11-25 at 19 13 51" src="https://cloud.githubusercontent.com/assets/1506941/11407366/4018984e-93aa-11e5-8365-8d4c32a88a78.png">

Fixes #5 
