### PR TITLE
use canonical link when it's available and has an href attribute

### DIFF
--- a/social-count.js
+++ b/social-count.js
@@ -1,11 +1,13 @@
 ;window.SocialCounts = function(el, options) {
-  if(!el)
+  if(!el) {
     return
+  }
 
   this.options = options || {};
 
-  if(document.querySelector('link[rel=canonical]') && document.querySelector('link[rel=canonical]').href)
+  if(document.querySelector('link[rel=canonical]') && document.querySelector('link[rel=canonical]').href) {
     var canonical = document.querySelector('link[rel=canonical]').href;
+  }
 
   this.url = this.options.url || (canonical ? canonical : window.location.href);
 

--- a/social-count.js
+++ b/social-count.js
@@ -3,7 +3,11 @@
     return
 
   this.options = options || {};
-  this.url = this.options.url || window.location.href;
+
+  if(document.querySelector('link[rel=canonical]') && document.querySelector('link[rel=canonical]').href)
+    var canonical = document.querySelector('link[rel=canonical]').href;
+
+  this.url = this.options.url || (canonical ? canonical : window.location.href);
 
   var networks = {
     twitter: twitter,


### PR DESCRIPTION
I've added a check for a canonical link with an href. If they are both present it's used and falls back to `window.location.href`.

Fixes #4 
